### PR TITLE
Update snippets for lesson 12

### DIFF
--- a/_extras/snippets_library/UCL_sge/12/explore.snip
+++ b/_extras/snippets_library/UCL_sge/12/explore.snip
@@ -5,7 +5,7 @@
 > instructors will give you the ID of the compute node to use):
 >
 > ```
-> {{ site.host_prompt }} pbsnodes r1i0n32
+> {{ site.host_prompt }} qhost -h node-c11a-001
 > ```
 > {: .language-bash}
 {: .challenge}

--- a/_extras/snippets_library/UCL_sge/12/explore.snip
+++ b/_extras/snippets_library/UCL_sge/12/explore.snip
@@ -5,7 +5,7 @@
 > instructors will give you the ID of the compute node to use):
 >
 > ```
-> {{ site.host_prompt }} qhost -h node-c11a-001
+> {{ site.host_prompt }} qhost -h node-d00a-001
 > ```
 > {: .language-bash}
 {: .challenge}

--- a/_extras/snippets_library/UCL_sge/12/info.snip
+++ b/_extras/snippets_library/UCL_sge/12/info.snip
@@ -1,6 +1,11 @@
-Unknown node type: util01
-    2 type * nodes: 40 cores, 188.6G RAM
-    3 type C nodes: 40 cores, 172.7G RAM
-    1 type C nodes: 40 cores, 172.8G RAM
-   36 type C nodes: 40 cores, 188.4G RAM
-  150 type C nodes: 40 cores, 188.6G RAM
+Unknown node type: util02
+Unknown node type: util05
+    2 type * nodes: 36 cores, 188.4G RAM
+    7 type B nodes: 36 cores,   1.5T RAM
+   66 type D nodes: 36 cores, 188.4G RAM
+    9 type E nodes: 36 cores, 188.4G RAM
+    1 type F nodes: 36 cores, 188.4G RAM
+    3 type H nodes: 36 cores, 172.7G RAM
+   53 type H nodes: 36 cores, 188.4G RAM
+    3 type I nodes: 36 cores,   1.5T RAM
+    2 type J nodes: 36 cores, 188.4G RAM

--- a/_extras/snippets_library/UCL_sge/12/info.snip
+++ b/_extras/snippets_library/UCL_sge/12/info.snip
@@ -1,21 +1,6 @@
-r1i0n32
-     Mom = r1i0n32.ib0.icexa.epcc.ed.ac.uk
-     ntype = PBS
-     state = offline
-     pcpus = 72
-     resources_available.arch = linux
-     resources_available.host = r1i0n32
-     resources_available.mem = 263773892kb
-     resources_available.ncpus = 36
-     resources_available.vnode = r1i0n32
-     resources_assigned.accelerator_memory = 0kb
-     resources_assigned.mem = 0kb
-     resources_assigned.naccelerators = 0
-     resources_assigned.ncpus = 0
-     resources_assigned.netwins = 0
-     resources_assigned.vmem = 0kb
-     resv_enable = True
-     sharing = default_shared
-     license = l
-
-...
+Unknown node type: util01
+    2 type * nodes: 40 cores, 188.6G RAM
+    3 type C nodes: 40 cores, 172.7G RAM
+    1 type C nodes: 40 cores, 172.8G RAM
+   36 type C nodes: 40 cores, 188.4G RAM
+  150 type C nodes: 40 cores, 188.6G RAM


### PR DESCRIPTION
* Info snippet uses `nodetypes` instead of `qhost` to give more compressed info about nodes.
* I picked node 001 arbitrarily for explore snippet, I assume there's no reason to pick any particular node.