### PR TITLE
Fix the broken decomposition

### DIFF
--- a/_episodes/16-parallel.md
+++ b/_episodes/16-parallel.md
@@ -471,6 +471,8 @@ We replace the `start_time` and `counts` lines with the lines:
 if rank == 0:
   start_time = datetime.datetime.now()
   partitions = [ int(n_samples / cpus) ] * cpus
+  for a in range(n_samples - sum(partitions)):
+    partitions[a] += 1
   counts = [ int(0) ] * cpus
 else:
   partitions = None

--- a/files/pi-mpi-minimal.py
+++ b/files/pi-mpi-minimal.py
@@ -17,6 +17,8 @@ if __name__ == '__main__':
     n_samples = int(sys.argv[1])
     if rank == 0:
         partitions = [ int(n_samples / cpus) ] * cpus
+        for a in range(n_samples - sum(partitions)):
+            partitions[a] += 1
         counts = [ int(0) ] * cpus
     else:
         partitions = None

--- a/files/pi-mpi.py
+++ b/files/pi-mpi.py
@@ -84,6 +84,11 @@ if __name__ == '__main__':
         # one for the number of samples they should run, and
         # one to store the count info each rank returns.
         partitions = [ int(n_samples / cpus) ] * cpus
+        # if the number of samples does not equally divide the number of 
+        # partitions, we need to tidy up - work out left over and add 1
+        # to each of that many partitions.
+        for a in range(n_samples - sum(partitions)):
+            partitions[a] += 1
         counts = [ int(0) ] * cpus
     else:
         partitions = None

--- a/files/pi-mpi.py
+++ b/files/pi-mpi.py
@@ -84,8 +84,8 @@ if __name__ == '__main__':
         # one for the number of samples they should run, and
         # one to store the count info each rank returns.
         partitions = [ int(n_samples / cpus) ] * cpus
-        # if the number of samples does not equally divide the number of 
-        # partitions, we need to tidy up - work out left over and add 1
+        # if the number of partitions does not equally divide the number of 
+        # samples, we need to tidy up - work out left over and add 1
         # to each of that many partitions.
         for a in range(n_samples - sum(partitions)):
             partitions[a] += 1


### PR DESCRIPTION
The decomposition of the parallel examples only works when the number of ranks exactly divides the number of time-steps.