### PR TITLE
Clarified about rsync in 15-transferring-files.md

### DIFF
--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -186,11 +186,11 @@ A trailing slash on the source directory is optional, and has no effect for
 > {: .language-bash}
 >
 > As written, this will place the local directory and its contents under the
-> specified directory on the remote system. If the trailing slash is omitted on
+> specified directory on the remote system. If a trailing slash is added to
 > the source, a new directory corresponding to the transferred directory
 > ('dir' in the example) will not be created, and the contents of the source
 > directory will be copied directly into the destination directory. Omitting
-> the trailing slash on the destination makes no difference.
+> or adding a trailing slash on the destination makes no difference.
 >
 > The `a` (archive) option implies recursion.
 >


### PR DESCRIPTION
I worked a quick example to check my sanity.

The example given just above this text is correct, but the text below didn't match it.

What occurs with the given example:
```bash
[myriad][ccaech0@login13 ~]$ ls example_dir
bar  foo
[myriad][ccaech0@login13 ~]$ rsync -avzP example_dir kathleen:example_dir
sending incremental file list
example_dir/
example_dir/bar
              0 100%    0.00kB/s    0:00:00 (xfr#1, to-chk=1/3)
example_dir/foo
              0 100%    0.00kB/s    0:00:00 (xfr#2, to-chk=0/3)

sent 178 bytes  received 58 bytes  52.44 bytes/sec
total size is 0  speedup is 0.00
...
[kathleen][ccaech0@login01 ~]$ ls example_dir/
example_dir
[kathleen][ccaech0@login01 ~]$ ls example_dir/example_dir/
bar  foo
[kathleen][ccaech0@login01 ~]$ rm -rf example_dir/*
```

What occurs in the discussed, but not shown example (`/` appended to the source):
```bash
[myriad][ccaech0@login13 ~]$ rsync -avzP example_dir/ kathleen:example_dir/
sending incremental file list
./
bar
              0 100%    0.00kB/s    0:00:00 (xfr#1, to-chk=1/3)
foo
              0 100%    0.00kB/s    0:00:00 (xfr#2, to-chk=0/3)

sent 157 bytes  received 57 bytes  38.91 bytes/sec
total size is 0  speedup is 0.00
...
[kathleen][ccaech0@login01 ~]$ ls example_dir/
bar  foo
```