### PR TITLE
Cdkharris/nodetypes->qhost

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,7 @@ sched:
   del: "qdel"
   interactive: "qrsh"
   info: "nodetypes"
+  hosts: "qhost"
   comment: "#$"
   hist: "jobhist"
 

--- a/_includes/snippets_library/UCL_Myriad_sge/cluster/specific-node-info.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/cluster/specific-node-info.snip
@@ -6,7 +6,7 @@
 > the compute node to use):
 >
 > ```
-> {{ site.remote.prompt }} {{ site.sched.info }} -h {{ site.remote.node }}
+> {{ site.remote.prompt }} {{ site.sched.hosts }} -h {{ site.remote.node }}
 > ```
 > {: .language-bash}
 {: .challenge}


### PR DESCRIPTION
The template expects us to use one utility both to show a summary of the system (`nodetypes`) and to show details for one node (`qhost -h <node name>`). It sort of looks like this functionality is supposed to be in `nodetypes` but I don't know enough about perl to figure out what's going on there. I created a new site-specific variable so we can refer to `qhost` in this snippet.