### PR TITLE
feat: Update the instructor notes for Fall 2024

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,10 +29,9 @@ local:
 
 remote:
   name: "Myriad"
-  host: "myriad.ucl.ac.uk"
   login: "myriad.rc.ucl.ac.uk"
   host: "login12.myriad.ucl.ac.uk"
-  node: node-d00a-001
+  node: node-d00a-005
   location: "University College London"
   homedir: "/home"
   user: "yourUsername"

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -218,7 +218,7 @@ later episode of this lesson.
 > >
 > > ```
 > > {{ site.remote.bash_shebang }}
-> > {{ site.sched.comment }} {{ site.sched.flag.time }}00:01:00 # timeout in HH:MM
+> > {{ site.sched.comment }} {{ site.sched.flag.time }}00:01:00 # timeout in HH:MM:SS
 > >
 > > echo -n "This script is running on "
 > > sleep 20 # time in seconds
@@ -247,7 +247,7 @@ wall time, and attempt to run a job for two minutes.
 ```
 {{ site.remote.bash_shebang }}
 {{ site.sched.comment }} {{ site.sched.flag.name }} long_job
-{{ site.sched.comment }} {{ site.sched.flag.time }} 00:01 # timeout in HH:MM
+{{ site.sched.comment }} {{ site.sched.flag.time }}00:01:00 # timeout in HH:MM:SS
 
 echo "This script is running on ... "
 sleep 240 # time in seconds

--- a/_episodes/15-modules.md
+++ b/_episodes/15-modules.md
@@ -197,7 +197,7 @@ Let's examine the output of `module avail` more closely.
 > > {{ site.remote.bash_shebang }}
 > > {{ site.sched.comment }} {{ site.sched.flag.partition }}{% if site.sched.flag.qos %}
 > > {{ site.sched.comment }} {{ site.sched.flag.qos }}
-> > {% endif %}{{ site.sched.comment }} {{ site.sched.flag.time }} 00:00:30
+> > {% endif %}{{ site.sched.comment }} {{ site.sched.flag.time }}00:00:30
 > > 
 > > module load {{ site.remote.module_python3 }}
 > >

--- a/_episodes/15-modules.md
+++ b/_episodes/15-modules.md
@@ -195,7 +195,7 @@ Let's examine the output of `module avail` more closely.
 > >
 > > ```
 > > {{ site.remote.bash_shebang }}
-> > {{ site.sched.comment }} {{ site.sched.flag.partition }}{% if site.sched.flag.qos %}
+> > {% if site.sched.flag.qos %}
 > > {{ site.sched.comment }} {{ site.sched.flag.qos }}
 > > {% endif %}{{ site.sched.comment }} {{ site.sched.flag.time }}00:00:30
 > > 

--- a/_episodes/17-parallel.md
+++ b/_episodes/17-parallel.md
@@ -38,8 +38,14 @@ Move into the extracted directory, then use the Package Installer for Python,
 or `pip`, to install it in your ("user") home directory:
 
 ```
-{{ site.remote.prompt }} cd amdahl
+{{ site.remote.prompt }} wget -O amdahl.tar.gz https://github.com/hpc-carpentry/amdahl/tarball/main
+{{ site.remote.prompt }} tar -xvzf amdahl.tar.gz
+{{ site.remote.prompt }} cd hpc-carpentry-amdahl-46c9b4b
+{{ site.remote.prompt }} module load python3/recommended
+{{ site.remote.prompt }} module unload compilers mpi
+{{ site.remote.prompt }} module load mpi4py
 {{ site.remote.prompt }} python3 -m pip install --user .
+{{ site.remote.prompt }} which amdahl
 ```
 {: .language-bash}
 

--- a/_episodes/18-resources.md
+++ b/_episodes/18-resources.md
@@ -113,7 +113,7 @@ get your job dispatched earlier.
 > > finish within 2 minutes:
 > >
 > > ```
-> > {{ site.sched.comment }} {{ site.sched.flag.time }}{% if site.sched.name == "Slurm" %} {% else %}={% endif %}00:02:00
+> > {{ site.sched.comment }} {{ site.sched.flag.time }}00:02:00
 > > ```
 > > {: .language-bash}
 > {: .solution}

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
@@ -44,7 +44,7 @@ So in this case, loading the `matlab` module also loaded `xorg-utils/X11R7.7`, s
 for supporting a graphic user interface. Let's try unloading the `matlab` package.
 
 ```
-{{ site.remote.prompt }} module unload GROMACS
+{{ site.remote.prompt }} module unload matlab
 {{ site.remote.prompt }} module list
 ```
 {: .language-bash}

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
@@ -1,67 +1,72 @@
-To demonstrate, let's load the `ansys` module and then use the `module list`
-command to show which modules we currently have loaded in our environment.
-([ANSYS](https://www.ansys.com/en-gb) is an engineering simulation product.)
+To demonstrate, let's use `module list`. `module list` shows all loaded
+software modules.
 
 ```
-{{ site.remote.prompt }} module load ansys
-```
-{: .language-bash}
-
-```
-ansys/2019.r3(73):ERROR:151: Module 'ansys/2019.r3' depends on one of the
-module(s) 'giflib/5.1.1'
-ansys/2019.r3(73):ERROR:102: Tcl command execution failed:
-prereq   giflib/5.1.1
-```
-{: .output}
-
-This shows that the default `ansys` module will not run because it first needs
-`giflib/5.1.1` to be loaded. Some HPC systems will automatically load
-dependencies like this, but at the time of writing (June 2020) UCL's Myriad
-does not.
-
-Let's load the `giflib` module:
-
-```
-{{ site.remote.prompt }} module load giflib
+{{ site.remote.prompt }} module list
 ```
 {: .language-bash}
 
 ```
-giflib/5.1.1(18):ERROR:151: Module 'giflib/5.1.1' depends on one of the
-module(s) 'gcc-libs/4.9.2'
-giflib/5.1.1(18):ERROR:102: Tcl command execution failed: prereq gcc-libs
+Currently Loaded Modulefiles:
+ 1) gcc-libs/4.9.2     10) nano/2.4.2         19) compilers/intel/2018/update3     
+ 2) cmake/3.21.1       11) nedit/5.6-aug15    20) mpi/intel/2018/update3/intel     
+ 3) flex/2.5.39        12) dos2unix/7.3       21) default-modules/2018             
+ 4) git/2.32.0         13) giflib/5.1.1       22) python/3.9.10                    
+ 5) apr/1.7.0          14) emacs/28.1         23) openblas/0.3.7-serial/gnu-4.9.2  
+ 6) apr-util/1.6.1     15) tmux/3.3a          24) python3/3.9                      
+ 7) subversion/1.14.1  16) mrxvt/0.5.4        25) python3/recommended              
+ 8) screen/4.9.0       17) userscripts/1.4.0  
+ 9) gerun              18) rcps-core/1.0.0
 ```
 {: .output}
 
-Here, we see that the `giflib` module itself also has a dependency, `gcc-libs`.
-So we have to load that first, then load `giflib`, and then finally load
-`ansys`.
-
 ```
-{{ site.remote.prompt }} module load gcc-libs/4.9.2
-{{ site.remote.prompt }} module load giflib/5.1.1
-{{ site.remote.prompt }} module load ansys
+{{ site.remote.prompt }} module load matlab
+{{ site.remote.prompt }} module list
 ```
 {: .language-bash}
 
 ```
-~/Scratch/.config is configured
-...
-...
-~/.mw doesn't exist - creating
+Currently Loaded Modulefiles:
+ 1) gcc-libs/4.9.2     10) nano/2.4.2         19) compilers/intel/2018/update3     
+ 2) cmake/3.21.1       11) nedit/5.6-aug15    20) mpi/intel/2018/update3/intel     
+ 3) flex/2.5.39        12) dos2unix/7.3       21) default-modules/2018             
+ 4) git/2.32.0         13) giflib/5.1.1       22) python/3.9.10                    
+ 5) apr/1.7.0          14) emacs/28.1         23) openblas/0.3.7-serial/gnu-4.9.2  
+ 6) apr-util/1.6.1     15) tmux/3.3a          24) python3/3.9                      
+ 7) subversion/1.14.1  16) mrxvt/0.5.4        25) python3/recommended              
+ 8) screen/4.9.0       17) userscripts/1.4.0  26) xorg-utils/X11R7.7               
+ 9) gerun              18) rcps-core/1.0.0    27) matlab/full/r2023a/9.14
 ```
 {: .output}
 
-If you now use the `module list` command, you should see these three modules
-included in the list.
+So in this case, loading the `matlab` module also loaded `xorg-utils/X11R7.7`, software
+for supporting a graphic user interface. Let's try unloading the `matlab` package.
 
-To unload a specific module, e.g. `ansys`, run the command
-`module unload ansys`. (On some systems, this will also unload the modules it
-depends on. Currently this is not the case with Myriad.)
+```
+{{ site.remote.prompt }} module unload GROMACS
+{{ site.remote.prompt }} module list
+```
+{: .language-bash}
 
-If we wanted to unload everything at once (all modules), we could run
-`module purge` (unloads everything).
+```
+Currently Loaded Modulefiles:
+ 1) gcc-libs/4.9.2     10) nano/2.4.2         19) compilers/intel/2018/update3     
+ 2) cmake/3.21.1       11) nedit/5.6-aug15    20) mpi/intel/2018/update3/intel     
+ 3) flex/2.5.39        12) dos2unix/7.3       21) default-modules/2018             
+ 4) git/2.32.0         13) giflib/5.1.1       22) python/3.9.10                    
+ 5) apr/1.7.0          14) emacs/28.1         23) openblas/0.3.7-serial/gnu-4.9.2  
+ 6) apr-util/1.6.1     15) tmux/3.3a          24) python3/3.9                      
+ 7) subversion/1.14.1  16) mrxvt/0.5.4        25) python3/recommended              
+ 8) screen/4.9.0       17) userscripts/1.4.0  
+ 9) gerun              18) rcps-core/1.0.0
+```
+{: .output}
+
+So using `module unload` "un-loads" a module, and depending on how a site is
+ configured it may also unload all of the dependencies (in our case it does
+ not). If we wanted to unload everything at once, we could run `module purge`
+ (unloads everything).
 
 ```
 {{ site.remote.prompt }} module purge
@@ -73,3 +78,7 @@ If we wanted to unload everything at once (all modules), we could run
 No Modulefiles Currently Loaded.
 ```
 {: .output}
+
+Note that `module purge` is informative. It will also let us know if a default
+set of "sticky" packages cannot be unloaded (and how to actually unload these
+if we truly so desired).

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
@@ -45,120 +45,53 @@ matlab and see what we get.
 {: .language-bash}
 
 ```
-matlab/full/r2019b/9.7(99):ERROR:151: Module 'matlab/full/r2019b/9.7'
-depends on one of the module(s) 'gcc-libs/4.9.2'
-matlab/full/r2019b/9.7(99):ERROR:102: Tcl command execution failed:
-prereq gcc-libs
+
+~/.matlab is a symbolic link pointing to /home/ccaech0/Scratch/.matlab
+
+Matlab setup complete type matlab to start Matlab.
+
+
+Loading matlab/full/r2023a/9.14
+  Loading requirement: gcc-libs/10.2.0 xorg-utils/X11R7.7
 ```
 {: .output}
 
-Here, we see that the default version of Matlab on the system is r2019b/9.7,
+Here, we see that the default version of Matlab on the system is `r2023a/9.14`,
 which in this case is the most recent version. However, you should not assume
 that the default version is necessarily the latest.
 
 As we saw in the earlier example, there are one or more dependencies.
 
 Suppose we decide to load an earlier version of Matlab, e.g. r2017a/9.2.
+You cannot load two different versions of the same software at once.
+Currently, we have loaded `matlab/full/r2023a/9.14`. Let's try also loading
+`matlab/full/r2021a/9.10`:
 
 ```
-{{ site.remote.prompt }} module purge
-{{ site.remote.prompt }} module list
+{{ site.remote.prompt }} module load matlab/full/r2021a/9.10
 ```
 {: .language-bash}
 
 ```
-No Modulefiles Currently Loaded.
-```
-{: .output}
-
-```
-{{ site.remote.prompt }} module load matlab/full/r2017a/9.2
-```
-{: .language-bash}
-
-```
-matlab/full/r2017a/9.2(96):ERROR:151: Module 'matlab/full/r2017a/9.2' depends
-on one of the module(s) 'gcc-libs/4.9.2'
-matlab/full/r2017a/9.2(96):ERROR:102: Tcl command execution failed:
-prereq gcc-libs
-```
-{: .output}
-
-```
-{{ site.remote.prompt }} module load gcc-libs/4.9.2
-{{ site.remote.prompt }} module load matlab/full/r2017a/9.2
-```
-{: .language-bash}
-
-```
-matlab/full/r2017a/9.2(97):ERROR:151: Module 'matlab/full/r2017a/9.2' depends
-on one of the module(s) 'xorg-utils/X11R7.7'
-matlab/full/r2017a/9.2(97):ERROR:102: Tcl command execution failed:
-prereq xorg-utils/X11R7.7
-```
-{: .output}
-
-```
-{{ site.remote.prompt }} module load xorg-utils/X11R7.7
-{{ site.remote.prompt }} module load matlab/full/r2017a/9.2
-```
-{: .language-bash}
-
-```
-~/.matlab is a symbolic link pointing to /home/yourUsername/Scratch/.matlab
-
-Matlab setup complete type matlab to start Matlab.
-```
-{: .output}
-
-```
-{{ site.remote.prompt }} matlab -nodisplay -nosplash -nodesktop
-```
-{: .language-bash}
-
-```
-                                               < M A T L A B (R) >
-                                     Copyright 1984-2017 The MathWorks, Inc.
-                                      R2017a (9.2.0.556344) 64-bit (glnxa64)
-                                                  March 27, 2017
-
-To get started, type one of these: helpwin, helpdesk, or demo.
-For product information, visit www.mathworks.com.
-
->> quit
-```
-{: .output}
-
-Note that you cannot load two different versions of the same software at once.
-Currently, we have loaded `matlab/full/r2017a/9.2`. Let's try also loading
-`matlab/full/r2015b/8.6`:
-
-```
-{{ site.remote.prompt }} module load matlab/full/r2015b/8.6
-```
-{: .language-bash}
-
-```
-matlab/full/r2015b/8.6(108):ERROR:150: Module 'matlab/full/r2015b/8.6'
-conflicts with the currently loaded module(s) 'matlab/full/r2017a/9.2'
-matlab/full/r2015b/8.6(108):ERROR:102: Tcl command execution failed:
-conflict matlab
+Loading matlab/full/r2021a/9.10
+  ERROR: Module cannot be loaded due to a conflict.
+    HINT: Might try "module unload matlab" first.
 ```
 {: .output}
 
 As we can see, we get an error message about conflicts.
-If we do indeed wish to load version r2015b/8.6, we can say
+If we do indeed wish to load version `r2021a/9.10`, we can say
 
 ```
-{{ site.remote.prompt }} module unload matlab/full/r2017a/9.2
-{{ site.remote.prompt }} module load matlab/full/r2015b/8.6
+{{ site.remote.prompt }} module unload matlab
+{{ site.remote.prompt }} module load matlab/full/r2021a/9.10
 ```
 {: .language-bash}
 
 or, in one step:
 
 ```
-{{ site.remote.prompt }} module swap matlab matlab/full/r2015b/8.6
+{{ site.remote.prompt }} module swap matlab/full/r2021a/9.10
 ```
 {: .language-bash}
 
@@ -171,10 +104,6 @@ Check that this module has been loaded:
 
 ```
 Currently Loaded Modulefiles:
-  1) gcc-libs/4.9.2        9) gerun           17) userscripts/1.4.0
-     ...                      ...                 ...
-  6) apr-util/1.5.4       14) emacs/24.5      22) xorg-utils/X11R7.7
-  7) subversion/1.8.13    15) tmux/2.2        23) matlab/full/r2015b/8.6
-  8) screen/4.2.1         16) mrxvt/0.5.4
+ 1) gcc-libs/10.2.0   2) xorg-utils/X11R7.7   3) matlab/full/r2021a/9.10
 ```
 {: .output}

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
@@ -46,7 +46,7 @@ matlab and see what we get.
 
 ```
 
-~/.matlab is a symbolic link pointing to /home/ccaech0/Scratch/.matlab
+~/.matlab is a symbolic link pointing to /home/yourUsername/Scratch/.matlab
 
 Matlab setup complete type matlab to start Matlab.
 

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
@@ -18,7 +18,7 @@
 > >
 > > ```
 > > {{ site.remote.bash_shebang }}
-> > {{ site.sched.comment }} {{ site.sched.time}}00:00:30
+> > {{ site.sched.comment }} {{ site.sched.flag.time}}00:00:30
 > >
 > > echo -n "This script is running on "
 > > hostname

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
@@ -18,7 +18,7 @@
 > >
 > > ```
 > > {{ site.remote.bash_shebang }}
-> > #SGE -l 00:00:30
+> > {{ site.sched.comment }} {{ site.sched.time}}00:00:30
 > >
 > > echo -n "This script is running on "
 > > hostname


### PR DESCRIPTION
Summary of updates by file:

- `_config.yml` Remove a duplicate variable and replace the node name with one that will play nicely with `qhost`
- `_episodes/*` Minor changes to correct the job scripts- Ideally some variables would be changed/added upstream but SGE is not planned to be supported in the future and there isn't a simpler way to do these.
- `_episodes/17-parallel.md` Add instructions for loading the python3 module- ideally this should be a new snippet but they're hoping to replace snippets with something else when the upstream lesson gets overhauled.
- UCL snippets
  - `modules/software-dependencies.snip` New modules now loads dependancies automatically in most cases. Yay!
  - `modules/wrong-gcc-version.snip` New modules lets us streamline this example. Yay!
  - `scheduler/print-sched-variables.snip` Correct SGE job scripts for the new environment variables lesson